### PR TITLE
Add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Add `rust-toolchain.toml` to define nightly toolchain

Trying to compile without nightly results in build failure due to unsupported features.

Adding the `rust-toolchain.toml` ensures that `cargo` automatically picks nightly toolchain (if installed).